### PR TITLE
Update gometalinter to version 2

### DIFF
--- a/golang/1.8/Dockerfile
+++ b/golang/1.8/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --update add build-base git bash \
     && go get -v -u github.com/stretchr/testify \
                 github.com/tebeka/go2xunit \
                 github.com/t-yuki/gocover-cobertura \
-                gopkg.in/alecthomas/gometalinter.v1 \
-    && gometalinter.v1 --install
+                gopkg.in/alecthomas/gometalinter.v2 \
+    && gometalinter.v2 --install
 
 ADD go-test-coverage-lint /usr/local/bin/

--- a/golang/1.8/go-test-coverage-lint
+++ b/golang/1.8/go-test-coverage-lint
@@ -39,15 +39,13 @@ function linters {
     echo "************************"
     echo "* Running gometalinter *"
     echo "************************"
-    gometalinter.v1 --checkstyle \
+    gometalinter.v2 --checkstyle \
                     --deadline=60s \
                     --disable-all \
                     --enable=errcheck \
                     --enable=golint \
-                    --enable=gosimple \
+                    --enable=megacheck \
                     --enable=misspell \
-                    --enable=staticcheck \
-                    --enable=unused \
                     --enable=vet \
                     --vendor \
                     $PKG > /log/checkstyle.xml

--- a/golang/1.9/Dockerfile
+++ b/golang/1.9/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --update add build-base git bash \
     && go get -v -u github.com/stretchr/testify \
                 github.com/tebeka/go2xunit \
                 github.com/t-yuki/gocover-cobertura \
-                gopkg.in/alecthomas/gometalinter.v1 \
-    && gometalinter.v1 --install
+                gopkg.in/alecthomas/gometalinter.v2 \
+    && gometalinter.v2 --install
 
 ADD go-test-coverage-lint /usr/local/bin/

--- a/golang/1.9/go-test-coverage-lint
+++ b/golang/1.9/go-test-coverage-lint
@@ -39,15 +39,13 @@ function linters {
     echo "************************"
     echo "* Running gometalinter *"
     echo "************************"
-    gometalinter.v1 --checkstyle \
+    gometalinter.v2 --checkstyle \
                     --deadline=60s \
                     --disable-all \
                     --enable=errcheck \
                     --enable=golint \
-                    --enable=gosimple \
+                    --enable=megacheck \
                     --enable=misspell \
-                    --enable=staticcheck \
-                    --enable=unused \
                     --enable=vet \
                     --vendor \
                     $PKG > /log/checkstyle.xml


### PR DESCRIPTION
**IMPORTANT**: I havent tried running this docker setup on my comp. I only ran the gometalinter directly.

version 2 runs a lot faster on my comp. 
https://github.com/alecthomas/gometalinter/releases

also they combined `gosimple`, `staticcheck` and `unused` into `megacheck` linter.