### PR TITLE
Use Alpine3.7 for Ruby 2.4 image

### DIFF
--- a/ruby/2.4-alpine-phantomjs/Dockerfile
+++ b/ruby/2.4-alpine-phantomjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.4-alpine3.7
 
 ENV TZ Asia/Singapore
 ENV PHANTOM_JS 2.1.1

--- a/ruby/2.4-alpine/Dockerfile
+++ b/ruby/2.4-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.4-alpine3.7
 
 ENV TZ Asia/Singapore
 


### PR DESCRIPTION
Alpine3.7 comes with a new version of `nodejs` which is necessary for downstream dependencies.