### PR TITLE
Move htcap up one directory for ZAP image

### DIFF
--- a/zap-scan/Dockerfile
+++ b/zap-scan/Dockerfile
@@ -24,5 +24,5 @@ RUN apk add --no-cache \
 
     # Install htcap & install python dependencies
     && cd /app \
-    && git clone https://github.com/segment-srl/htcap.git \
+    && git clone https://github.com/segment-srl/htcap.git . \
     && pip install requests python-owasp-zap-v2.4

--- a/zap-scan/Dockerfile
+++ b/zap-scan/Dockerfile
@@ -25,4 +25,5 @@ RUN apk add --no-cache \
     # Install htcap & install python dependencies
     && cd /app \
     && git clone https://github.com/segment-srl/htcap.git . \
+    && touch __init__.py \
     && pip install requests python-owasp-zap-v2.4


### PR DESCRIPTION
This is so that htcap can be used as a module in another python file.