### PR TITLE
Add dockerize for zap-scan

### DIFF
--- a/ruby/2.4-alpine-phantomjs/Dockerfile
+++ b/ruby/2.4-alpine-phantomjs/Dockerfile
@@ -22,7 +22,6 @@ RUN \
                libxslt-dev \
     && bundle config --global jobs 4 \
     && adduser -S -h /app -u 10000 app \
-
     # Install phantomjs
     && cd /tmp \
     && wget -U "awesome browser" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOM_JS-linux-x86_64.tar.bz2  \

--- a/ruby/2.5-alpine-phantomjs/Dockerfile
+++ b/ruby/2.5-alpine-phantomjs/Dockerfile
@@ -22,7 +22,6 @@ RUN \
                libxslt-dev \
     && bundle config --global jobs 4 \
     && adduser -S -h /app -u 10000 app \
-
     # Install phantomjs
     && cd /tmp \
     && wget -U "awesome browser" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOM_JS-linux-x86_64.tar.bz2  \

--- a/zap-scan/Dockerfile
+++ b/zap-scan/Dockerfile
@@ -1,5 +1,6 @@
 FROM moexmen/alpine:3.7
 ENV PHANTOM_JS 2.1.1
+ENV DOCKERIZE_VERSION v0.6.1
 
 # Install required packages
 RUN apk add --no-cache \
@@ -12,6 +13,7 @@ RUN apk add --no-cache \
         sqlite \
         tar \
         wget \
+        openssl \
     && rm -rf /var/cache/apk/* \
 
     # Install PhantomJS
@@ -26,4 +28,9 @@ RUN apk add --no-cache \
     && cd /app \
     && git clone https://github.com/segment-srl/htcap.git . \
     && touch __init__.py \
-    && pip install requests python-owasp-zap-v2.4
+    && pip install requests python-owasp-zap-v2.4 \
+
+    # Install dockerize
+    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/zap-scan/Dockerfile
+++ b/zap-scan/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --no-cache \
         wget \
         openssl \
     && rm -rf /var/cache/apk/* \
-
     # Install PhantomJS
     && cd /tmp \
     && wget -U "awesome browser" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOM_JS-linux-x86_64.tar.bz2  \
@@ -23,13 +22,11 @@ RUN apk add --no-cache \
     && cp phantomjs-$PHANTOM_JS-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs \
     && rm -rf phanomjs-$PHANTOM_JS-linux-x86_64* \
     && curl -Ls "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / \
-
     # Install htcap & install python dependencies
     && cd /app \
     && git clone https://github.com/segment-srl/htcap.git . \
     && touch __init__.py \
     && pip install requests python-owasp-zap-v2.4 \
-
     # Install dockerize
     && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
Got this warning `Empty continuation lines will become errors in a future release.` when building the images. Do we want to remove the empty lines now, or next time?