### PR TITLE
Change gas to gosec

### DIFF
--- a/golang/1.10/Dockerfile
+++ b/golang/1.10/Dockerfile
@@ -12,6 +12,6 @@ RUN apk --no-cache add build-base git bash \
                 github.com/moexmen/gas-report-filter \
     && gometalinter.v2 --install \
     # Needs to be installed last to override outdated version in gometalinter
-    && go get github.com/GoASTScanner/gas/cmd/gas/...
+    && go get github.com/securego/gosec/cmd/gosec/...
 
 COPY go-test-coverage-lint go-ast-scanner /usr/local/bin/

--- a/golang/1.10/go-ast-scanner
+++ b/golang/1.10/go-ast-scanner
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 mkdir -p /log
-gas -exclude=$GLOBAL_WHITELIST -fmt=junit-xml ./... | gas-report-filter -whitelist whitelist.json > /log/report.xml
+gosec -exclude=$GLOBAL_WHITELIST -fmt=junit-xml ./... | gas-report-filter -whitelist whitelist.json > /log/report.xml

--- a/golang/1.9/Dockerfile
+++ b/golang/1.9/Dockerfile
@@ -12,6 +12,6 @@ RUN apk --no-cache add build-base git bash \
                 github.com/moexmen/gas-report-filter \
     && gometalinter.v2 --install \
     # Needs to be installed last to override outdated version in gometalinter
-    && go get github.com/GoASTScanner/gas/cmd/gas/...
+    && go get github.com/securego/gosec/cmd/gosec/...
 
 COPY go-test-coverage-lint go-ast-scanner /usr/local/bin/

--- a/golang/1.9/go-ast-scanner
+++ b/golang/1.9/go-ast-scanner
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 mkdir -p /log
-gas -exclude=$GLOBAL_WHITELIST -fmt=junit-xml ./... | gas-report-filter -whitelist whitelist.json > /log/report.xml
+gosec -exclude=$GLOBAL_WHITELIST -fmt=junit-xml ./... | gas-report-filter -whitelist whitelist.json > /log/report.xml


### PR DESCRIPTION
There is a change of name for `gas`: https://github.com/securego/gosec/pull/216

Additionally, I think we can safely leave the installation of `gosec` here given that they don't update their rules very often:

<img width="1047" alt="screen shot 2018-08-01 at 10 10 04 am" src="https://user-images.githubusercontent.com/6241720/43497087-1a97edfe-9573-11e8-9ea0-768ce5ea3228.png">
