### PR TITLE
Update domain name used for forwarding

### DIFF
--- a/socat/docker-entrypoint.sh
+++ b/socat/docker-entrypoint.sh
@@ -4,11 +4,13 @@ if [[ $# -ne 0 ]]; then
     exec "$@"
 else
     if [[ -z "$TARGET_HOST" ]]; then
-        # On the mac, the `docker.for.mac.localhost` resolves
+        # On windows and mac, the `host.docker.internal` resolves
         # to the host ip
-        getent hosts docker.for.mac.localhost > /dev/null
+        # Linux doesn't work properly yet, see below
+        # https://github.com/docker/for-linux/issues/264
+        getent hosts host.docker.internal > /dev/null
         if [[ $? -eq 0 ]]; then
-            TARGET_HOST=docker.for.mac.localhost
+            TARGET_HOST=host.docker.internal
         else
             TARGET_HOST=$(ip route | grep default | awk "{print \$3}")
         fi


### PR DESCRIPTION
Current implementation works for mac, but (probably) not for Windows nor Linux. Changing the domain name to one that aligns with what should be docker's intended implementation.

Refer to https://github.com/docker/for-linux/issues/264 for an explanation of what's available for windows and mac, as well as the issue with the same domain name on Linux.