### PR TITLE
Update zap image

### DIFF
--- a/zap-scan/Dockerfile
+++ b/zap-scan/Dockerfile
@@ -13,16 +13,10 @@ RUN apk add --no-cache \
         tar \
         wget \
         openssl \
+        nodejs \
     && rm -rf /var/cache/apk/* \
-    # Install PhantomJS
-    && cd /tmp \
-    && wget -U "awesome browser" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOM_JS-linux-x86_64.tar.bz2  \
-    && tar -xjf phantomjs-$PHANTOM_JS-linux-x86_64.tar.bz2 \
-    && cp phantomjs-$PHANTOM_JS-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs \
-    && rm -rf phantomjs-$PHANTOM_JS-linux-x86_64* \
-    && curl -Ls "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / \
     # Install htcap & install python dependencies
     && cd /app \
-    && git clone https://github.com/segment-srl/htcap.git . \
+    && git clone https://github.com/fcavallarin/htcap.git . \
     && touch __init__.py \
     && pip install requests python-owasp-zap-v2.4


### PR DESCRIPTION
Install `nodejs` as htcap no longer uses phantomJS for web crawling. Refer to: https://github.com/fcavallarin/htcap/commit/4e98aa11598ff4506874e54703fc89bef1d68312

@abeltay whoops. cleaned it up liao, thanks!