### PR TITLE
Add golang 1.12 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
 - TESTFOLDER=alpine/3.8
 - TESTFOLDER=golang/1.10
 - TESTFOLDER=golang/1.11/alpine3.8
+- TESTFOLDER=golang/1.12/alpine3.9
 - TESTFOLDER=jenkins
 - TESTFOLDER=node/8
 - TESTFOLDER=node/8-chromium


### PR DESCRIPTION
> 978659374e705d1d41e1d64389247f450cf4f31e added golang:1.12-alpine3.9 image

This PR updates the travis config to test the changes.